### PR TITLE
Fix systemd ExecStart missing npm path

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -252,8 +252,9 @@ if $SERVICE; then
   info "Configuring systemd service: $SERVICE_NAME ..."
   $SUDO mkdir -p "$LOG_DIR"
   $SUDO chown "$SERVICE_USER:$SERVICE_USER" "$LOG_DIR"
-  NODE_BIN="$(command -v node)"
-  NPM_BIN="$(command -v npm)"
+  NODE_BIN="$(command -v node || which node 2>/dev/null || echo /usr/bin/node)"
+  NPM_BIN="$(command -v npm || which npm 2>/dev/null || echo /usr/bin/npm)"
+  [[ -x "$NPM_BIN" ]] || die "npm not found — cannot create systemd service"
   $SUDO tee "$SERVICE_FILE" > /dev/null <<UNIT
 [Unit]
 Description=doc-it Documentation Platform


### PR DESCRIPTION
## Summary

Fixes #2 — The Linux installer's `--service` flag generated `ExecStart= start` instead of `ExecStart=/usr/bin/npm start`.

### Root Cause

`command -v npm` returns empty when the script runs under `sudo` and npm isn't in root's PATH. The empty `NPM_BIN` variable produced a broken systemd unit file.

### Fix

Added a fallback chain in `install-linux.sh` (line 255-257):

```bash
NODE_BIN="$(command -v node || which node 2>/dev/null || echo /usr/bin/node)"
NPM_BIN="$(command -v npm || which npm 2>/dev/null || echo /usr/bin/npm)"
[[ -x "$NPM_BIN" ]] || die "npm not found — cannot create systemd service"
```

- Tries `command -v`, falls back to `which`, falls back to `/usr/bin/npm`
- Validates the resolved path is executable before writing the unit file
- Aborts with a clear error if npm truly can't be found

Co-Authored-By: Oz <oz-agent@warp.dev>