### PR TITLE
Show feedback popup when applying certificate templates

### DIFF
--- a/src/components/admin/CertificatesTab.tsx
+++ b/src/components/admin/CertificatesTab.tsx
@@ -1059,11 +1059,11 @@ export default function CertificatesTab() {
                         if (!tpl) return null;
                         return (
                           <div className="flex gap-1 flex-shrink-0">
-                            <button onClick={() => setCsrForm(applyTemplateToCsr(tpl, "extensions", csrForm))}
+                            <button onClick={() => { setCsrForm(applyTemplateToCsr(tpl, "extensions", csrForm)); flash("Extensions applied from template", "success"); }}
                               className="px-2 py-1 text-xs border border-border rounded hover:bg-muted whitespace-nowrap">Apply extensions</button>
-                            <button onClick={() => setCsrForm(applyTemplateToCsr(tpl, "subject", csrForm))}
+                            <button onClick={() => { setCsrForm(applyTemplateToCsr(tpl, "subject", csrForm)); flash("Subject applied from template", "success"); }}
                               className="px-2 py-1 text-xs border border-border rounded hover:bg-muted whitespace-nowrap">Apply subject</button>
-                            <button onClick={() => setCsrForm(applyTemplateToCsr(tpl, "all", csrForm))}
+                            <button onClick={() => { setCsrForm(applyTemplateToCsr(tpl, "all", csrForm)); flash("Template applied", "success"); }}
                               className="px-2 py-1 text-xs bg-accent text-white rounded hover:bg-accent-hover whitespace-nowrap">Apply all</button>
                           </div>
                         );


### PR DESCRIPTION
## Summary

Fixes #7 — Clicking 'Apply extensions', 'Apply subject', or 'Apply all' in the certificate manager CSR form now shows a confirmation flash message.

### Change

Added `flash()` calls to the three template apply buttons in `src/components/admin/CertificatesTab.tsx`:
- **Apply extensions** → "Extensions applied from template"
- **Apply subject** → "Subject applied from template"
- **Apply all** → "Template applied"

Co-Authored-By: Oz <oz-agent@warp.dev>