### PR TITLE
Fix service file permissions and document ownership requirements

### DIFF
--- a/documentation/installation.md
+++ b/documentation/installation.md
@@ -214,6 +214,72 @@ The super-admin can never be deleted and always retains full access to all featu
 
 ---
 
+## File Permissions & Service User
+
+When installed as a system service (`--service`), doc-it runs under a **dedicated service user** that needs read/write access to the install directory and all runtime data directories.
+
+### How it works per platform
+
+**Linux** — The installer creates a `doc-it` system user and group. All files under the install directory (default `/opt/doc-it`) are owned by `doc-it:doc-it`. The systemd unit runs the process as this user.
+
+**macOS** — The launchd service runs as the user who ran the installer (typically your normal macOS user account). The install directory is owned by that user.
+
+**Windows** — The NSSM service runs as `SYSTEM`, which has full access. No special permission setup is needed.
+
+### Writable directories
+
+The following directories must be writable by the service user. The installer pre-creates them automatically, but if you set up manually or move the install directory you must ensure correct ownership:
+
+```
+<install-dir>/
+├── config/       # SQLite database (docit.db), avatars
+├── docs/         # Markdown documents, databases, attachments
+├── logs/         # Audit logs, crash logs
+├── archive/      # Archived documents
+├── history/      # Document revision history
+├── backups/      # Encrypted backup archives
+├── trash/        # Soft-deleted documents
+└── .next/        # Next.js build cache (written during build + runtime)
+```
+
+### Troubleshooting permission errors
+
+If doc-it starts but returns errors when logging in, creating documents, or saving settings, the service user likely cannot write to the data directories.
+
+**Linux — fix ownership:**
+```bash
+sudo chown -R doc-it:doc-it /opt/doc-it
+```
+
+**macOS — fix ownership** (replace `youruser` with the user that runs the service):
+```bash
+sudo chown -R youruser /opt/doc-it
+```
+
+**Verify the service user:**
+```bash
+# Linux — check which user the service runs as
+ps -eo user,comm | grep node
+
+# Linux — check directory ownership
+ls -la /opt/doc-it/
+```
+
+After fixing permissions, restart the service:
+```bash
+# Linux
+sudo systemctl restart doc-it
+
+# macOS
+sudo launchctl stop com.talder.docit && sudo launchctl start com.talder.docit
+```
+
+### Manual installation note
+
+If you install manually (without `--service`), doc-it runs as the current user and writes to the current working directory. Ensure the user running `npm start` has write access to the project directory.
+
+---
+
 ## Data Storage
 
 All data is stored on disk in several top-level directories (created automatically on first run):

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -222,12 +222,19 @@ else
   $SUDO git $GIT_SSL clone "$REPO" "$INSTALL_DIR"
 fi
 
-# ── 4. Service user ────────────────────────────────────────────
+# ── 4. Service user & permissions ──────────────────────────────
 if $SERVICE; then
   if ! id "$SERVICE_USER" &>/dev/null; then
     info "Creating service user: $SERVICE_USER ..."
     $SUDO useradd -r -s /bin/false -d "$INSTALL_DIR" "$SERVICE_USER"
   fi
+  # Pre-create runtime data directories so the service user can
+  # write to the SQLite database, documents, logs, etc. from the
+  # very first request.  These are gitignored and only exist at runtime.
+  info "Setting file permissions for service user: $SERVICE_USER ..."
+  for dir in config docs logs archive history backups trash; do
+    $SUDO mkdir -p "$INSTALL_DIR/$dir"
+  done
   $SUDO chown -R "$SERVICE_USER:$SERVICE_USER" "$INSTALL_DIR"
 else
   $SUDO chown -R "$(whoami)" "$INSTALL_DIR"

--- a/install-mac.sh
+++ b/install-mac.sh
@@ -227,17 +227,28 @@ npm install $( $NO_SSL && echo "--strict-ssl=false" || echo "" )
 info "Building production bundle..."
 npm run build
 
-# ── 6. Service (launchd) ───────────────────────────────────────
+# ── 6. Service (launchd) ───────────────────────────────────
 if $SERVICE; then
   info "Configuring launchd service: $SERVICE_LABEL ..."
-  NPM_PATH="$(command -v npm)"
-  NODE_PATH="$(command -v node)"
+  NPM_PATH="$(command -v npm || which npm 2>/dev/null || echo /usr/local/bin/npm)"
+  NODE_PATH="$(command -v node || which node 2>/dev/null || echo /usr/local/bin/node)"
+  SERVICE_RUN_USER="$(whoami)"
+  SERVICE_RUN_GROUP="$(id -gn)"
+
+  # Pre-create runtime data directories with correct ownership
+  for dir in config docs logs archive history backups trash; do
+    mkdir -p "$INSTALL_DIR/$dir"
+  done
+
   sudo mkdir -p "$LOG_DIR"
+  sudo chown "$SERVICE_RUN_USER" "$LOG_DIR"
   sudo tee "$SERVICE_PLIST" > /dev/null <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict>
   <key>Label</key>             <string>${SERVICE_LABEL}</string>
+  <key>UserName</key>          <string>${SERVICE_RUN_USER}</string>
+  <key>GroupName</key>         <string>${SERVICE_RUN_GROUP}</string>
   <key>ProgramArguments</key>  <array>
     <string>${NPM_PATH}</string><string>start</string>
   </array>
@@ -255,7 +266,7 @@ if $SERVICE; then
 PLIST
   sudo launchctl unload "$SERVICE_PLIST" 2>/dev/null || true
   sudo launchctl load -w "$SERVICE_PLIST"
-  info "Service started. Logs: $LOG_DIR"
+  info "Service started (running as $SERVICE_RUN_USER). Logs: $LOG_DIR"
 fi
 
 # ── Done ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #9 — The service user (`doc-it` on Linux) could not write to the SQLite database or document directories because the runtime data directories didn't exist yet at first boot.

### Root Cause

The installer creates a `doc-it` system user and sets ownership of the install directory, but the runtime data directories (`config/`, `docs/`, `logs/`, etc.) are gitignored and only created at runtime. When the app tried to create them on first request, it could fail depending on the umask or parent directory permissions.

### Changes

**`install-linux.sh`:**
- Pre-create all 7 runtime data directories (`config`, `docs`, `logs`, `archive`, `history`, `backups`, `trash`) with `doc-it:doc-it` ownership before the service starts

**`install-mac.sh`:**
- Add `UserName`/`GroupName` to the launchd plist so the service runs as the installing user instead of root
- Pre-create runtime data directories with correct ownership
- Add fallback chain for npm/node path resolution (matching the Linux fix from #2)

**`documentation/installation.md`:**
- New "File Permissions & Service User" section covering:
  - Per-platform service user details (Linux, macOS, Windows)
  - List of directories that must be writable
  - Troubleshooting commands for permission errors
  - Manual installation notes

Co-Authored-By: Oz <oz-agent@warp.dev>