### PR TITLE
Auto-logout user when session expires or idle timeout is reached

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { CopyToastProvider } from "@/components/CopyToast";
 import CrashReporter from "@/components/CrashReporter";
+import SessionGuard from "@/components/SessionGuard";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -25,6 +26,7 @@ export default function RootLayout({
         <ThemeProvider>
           <CopyToastProvider>
             <CrashReporter />
+            <SessionGuard />
             {children}
           </CopyToastProvider>
         </ThemeProvider>

--- a/src/components/SessionGuard.tsx
+++ b/src/components/SessionGuard.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter, usePathname } from "next/navigation";
+
+/**
+ * Periodically checks whether the user's session is still valid by
+ * calling /api/auth/me.  If the session has expired (server returns
+ * no user), the browser is redirected to /login.
+ *
+ * The check runs every 60 seconds.  It is skipped on pages that
+ * don't require authentication (login, register, setup, share, portal).
+ */
+
+const CHECK_INTERVAL_MS = 60_000; // 1 minute
+
+const PUBLIC_PREFIXES = ["/login", "/register", "/setup", "/share/", "/portal"];
+
+export default function SessionGuard() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    // Don't run on public pages
+    if (PUBLIC_PREFIXES.some((p) => pathname.startsWith(p))) return;
+
+    const check = async () => {
+      try {
+        const res = await fetch("/api/auth/me", { cache: "no-store" });
+        if (!res.ok) { router.replace("/login"); return; }
+        const data = await res.json();
+        if (!data.user) {
+          router.replace("/login");
+        }
+      } catch {
+        // Network error — don't redirect (offline tolerance)
+      }
+    };
+
+    // Run the first check after a short delay (avoid immediate call on mount)
+    const initial = setTimeout(check, 5_000);
+    intervalRef.current = setInterval(check, CHECK_INTERVAL_MS);
+
+    return () => {
+      clearTimeout(initial);
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [pathname, router]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Fixes #1 — Users are now automatically redirected to the login page when their session expires or the idle timeout is reached, instead of being left on a broken page where actions silently fail.

### Problem

When a user stays on a page and the server-side session expires (8h absolute TTL or 1h idle timeout), the UI remains visible but all API calls fail silently. This causes confusing behavior: editing documents that can't be saved, clicking buttons that do nothing, etc.

### Solution

New `SessionGuard` component (`src/components/SessionGuard.tsx`) added to the root layout that:
- Polls `/api/auth/me` every **60 seconds**
- Redirects to `/login` when the server reports no valid session
- **Skips** polling on public pages (login, register, setup, share, portal)
- **Tolerates** network errors without redirecting (offline-friendly)

The server's existing session validation (`getSessionUser` in `auth.ts`) already handles idle timeout detection and session expiry — the `SessionGuard` simply detects when that validation fails and acts on it client-side.

Co-Authored-By: Oz <oz-agent@warp.dev>