### PR TITLE
feat: Column layout extension (2/3 columns with drag-to-resize)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3175,6 +3175,138 @@ select.modal-input {
   background: var(--color-muted);
 }
 
+/* === Column Layout === */
+.column-layout {
+  position: relative;
+  margin: 1rem 0;
+  border: 1px dashed var(--color-border);
+  border-radius: 8px;
+  padding: 4px 0;
+}
+
+.column-layout:hover {
+  border-color: var(--color-accent);
+}
+
+.column-layout-inner {
+  position: relative;
+  display: flex;
+  min-height: 60px;
+}
+
+/* NodeViewContent renders the ProseMirror children – make it a flex row */
+.column-layout-content {
+  display: flex;
+  width: 100%;
+  min-height: 60px;
+}
+
+/* Each columnBlock child fills its share of the row */
+.column-layout-content > .column-block {
+  min-width: 0;
+  min-height: 40px;
+  padding: 8px 12px;
+}
+
+.column-layout-content > .column-block + .column-block {
+  border-left: 1px solid var(--color-border);
+}
+
+/* Dynamic widths via CSS custom properties set on the wrapper */
+.column-layout-content > .column-block:nth-child(1) {
+  flex: var(--col-w1, 1) 1 0%;
+}
+.column-layout-content > .column-block:nth-child(2) {
+  flex: var(--col-w2, 1) 1 0%;
+}
+.column-layout-content > .column-block:nth-child(3) {
+  flex: var(--col-w3, 1) 1 0%;
+}
+
+/* Resize handle between columns */
+.column-resize-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 8px;
+  transform: translateX(-50%);
+  cursor: col-resize;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+}
+
+.column-resize-handle::after {
+  content: "";
+  width: 3px;
+  height: 32px;
+  border-radius: 2px;
+  background: var(--color-border);
+  transition: background 0.12s, height 0.12s;
+}
+
+.column-resize-handle:hover::after,
+.column-resize-handle.active::after {
+  background: var(--color-accent);
+  height: 48px;
+}
+
+/* Floating toolbar (top-right) */
+.column-layout-toolbar {
+  position: absolute;
+  top: -32px;
+  right: 4px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px 4px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  box-shadow: 0 2px 8px var(--color-shadow);
+  z-index: 20;
+  user-select: none;
+}
+
+.column-toolbar-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: none;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  transition: background 0.12s, color 0.12s;
+}
+
+.column-toolbar-btn:hover {
+  background: var(--color-muted);
+  color: var(--color-text-primary);
+}
+
+.column-toolbar-btn-danger:hover {
+  background: #fee2e2;
+  color: #ef4444;
+}
+
+/* Read-mode: hide dashed border and toolbar affordances */
+.read-mode .column-layout {
+  border-color: transparent;
+}
+
+.read-mode .column-layout:hover {
+  border-color: transparent;
+}
+
+.read-mode .column-resize-handle {
+  display: none;
+}
+
 /* === Collapsible Block === */
 .collapsible-block {
   border: 1px solid var(--color-border);

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -57,6 +57,7 @@ import { TemplatePlaceholderExtension } from "./extensions/TemplatePlaceholderEx
 import { EmojiShortcodeExtension } from "./extensions/EmojiShortcodeExtension";
 import { DatabaseBlockExtension } from "./extensions/DatabaseBlockExtension";
 import type { DatabaseBlockAttrs } from "./extensions/DatabaseBlockExtension";
+import { ColumnLayout, ColumnBlock } from "./extensions/ColumnLayoutExtension";
 import { Extension } from "@tiptap/core";
 import { Plugin as PmPlugin, PluginKey as PmPluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
@@ -318,6 +319,20 @@ const markedCalloutExtension: MarkedExtension = {
         } catch { return null; }
       }) ?? out;
 
+      // column layout
+      out = replaceComment(out, /<!--\s*columns:([A-Za-z0-9+/=]+)\s*-->/, (m) => {
+        try {
+          const a = JSON.parse(atob(m[1]));
+          const cols = a.columns || 2;
+          const widths = a.widths || "50,50";
+          const colHtml = (a.content || []).map((md: string) => {
+            const inner = marked.parse(md, { async: false }) as string;
+            return `<div data-type="columnBlock" class="column-block">${inner || "<p></p>"}</div>`;
+          }).join("");
+          return `<div data-type="columnLayout" data-columns="${cols}" data-widths="${widths}" class="column-layout">${colHtml}</div>`;
+        } catch { return null; }
+      }) ?? out;
+
       return out;
     },
   },
@@ -527,6 +542,25 @@ turndown.addRule("databaseBlock", {
       spaceSlug: el.getAttribute("data-space-slug")  || "",
     };
     return `\n<!-- database:${btoa(JSON.stringify(attrs))} -->\n\n`;
+  },
+});
+
+// Column layout serialization — columnBlock emits a separator so
+// the parent columnLayout can split columns apart.
+const COLUMN_SEP = "\n<!--COL_SEP-->\n";
+turndown.addRule("columnBlock", {
+  filter: (node) => node.nodeName === "DIV" && node.getAttribute("data-type") === "columnBlock",
+  replacement: (content) => COLUMN_SEP + content,
+});
+turndown.addRule("columnLayout", {
+  filter: (node) => node.nodeName === "DIV" && node.getAttribute("data-type") === "columnLayout",
+  replacement: (content, node) => {
+    const el = node as HTMLElement;
+    const columns = parseInt(el.getAttribute("data-columns") || "2", 10);
+    const widths = el.getAttribute("data-widths") || "50,50";
+    const parts = content.split(COLUMN_SEP).filter(Boolean);
+    const payload = { columns, widths, content: parts.map((s: string) => s.trim()) };
+    return `\n<!-- columns:${btoa(JSON.stringify(payload))} -->\n\n`;
   },
 });
 // Preserve template placeholder spans
@@ -1056,6 +1090,8 @@ export default function Editor({ filename, initialMarkdown, onSave, spaceSlug, c
       MentionNode,
       MentionSuggestion,
       DatabaseBlockExtension,
+      ColumnLayout,
+      ColumnBlock,
       Extension.create({
         name: "tabHandler",
         addKeyboardShortcuts() {

--- a/src/components/extensions/ColumnLayoutExtension.tsx
+++ b/src/components/extensions/ColumnLayoutExtension.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { Node, mergeAttributes } from "@tiptap/core";
+import { NodeViewWrapper, NodeViewContent, ReactNodeViewRenderer } from "@tiptap/react";
+import { FC, useRef, useState, useCallback, useEffect } from "react";
+import { Trash2, Columns2, Columns3 } from "lucide-react";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function defaultWidths(cols: number): string {
+  if (cols === 3) return "33,34,33";
+  return "50,50";
+}
+
+function parseWidths(raw: string): number[] {
+  return raw.split(",").map((s) => parseFloat(s.trim()) || 0);
+}
+
+// ── ColumnBlock node (individual column) ─────────────────────────────────────
+
+export const ColumnBlock = Node.create({
+  name: "columnBlock",
+  // Not in "block" group – only valid inside columnLayout
+  group: "",
+  content: "block+",
+  defining: true,
+  isolating: true,
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="columnBlock"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, {
+        "data-type": "columnBlock",
+        class: "column-block",
+      }),
+      0,
+    ];
+  },
+});
+
+// ── ColumnLayout NodeView (React) ────────────────────────────────────────────
+
+const ColumnLayoutNodeView: FC<any> = ({ node, updateAttributes, deleteNode, editor }) => {
+  const columns: number = node.attrs.columns || 2;
+  const widths = parseWidths(node.attrs.widths || defaultWidths(columns));
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+  const dragStartXRef = useRef(0);
+  const dragStartWidthsRef = useRef<number[]>([]);
+  const [showToolbar, setShowToolbar] = useState(false);
+
+  // Clamp widths so no column goes below 15%
+  const clampWidths = (w: number[]): number[] => {
+    const min = 15;
+    const total = w.reduce((a, b) => a + b, 0);
+    return w.map((v) => Math.max(min, Math.min(total - min * (w.length - 1), v)));
+  };
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent, handleIndex: number) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setDraggingIndex(handleIndex);
+      dragStartXRef.current = e.clientX;
+      dragStartWidthsRef.current = [...widths];
+    },
+    [widths],
+  );
+
+  useEffect(() => {
+    if (draggingIndex === null) return;
+    const containerWidth = containerRef.current?.offsetWidth || 800;
+
+    const onMouseMove = (e: MouseEvent) => {
+      const dx = e.clientX - dragStartXRef.current;
+      const pctDelta = (dx / containerWidth) * 100;
+      const newWidths = [...dragStartWidthsRef.current];
+      newWidths[draggingIndex] += pctDelta;
+      newWidths[draggingIndex + 1] -= pctDelta;
+      const clamped = clampWidths(newWidths);
+      // Normalize to sum to 100
+      const sum = clamped.reduce((a, b) => a + b, 0);
+      const normalized = clamped.map((v) => Math.round((v / sum) * 100));
+      // Fix rounding – ensure they sum to exactly 100
+      const diff = 100 - normalized.reduce((a, b) => a + b, 0);
+      if (diff !== 0) normalized[normalized.length - 1] += diff;
+      updateAttributes({ widths: normalized.join(",") });
+    };
+
+    const onMouseUp = () => {
+      setDraggingIndex(null);
+    };
+
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+    return () => {
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onMouseUp);
+    };
+  }, [draggingIndex, updateAttributes]);
+
+  const toggleColumns = () => {
+    if (columns === 2) {
+      updateAttributes({ columns: 3, widths: "33,34,33" });
+    } else {
+      updateAttributes({ columns: 2, widths: "50,50" });
+    }
+  };
+
+  return (
+    <NodeViewWrapper
+      className="column-layout"
+      data-type="columnLayout"
+      data-columns={columns}
+      style={{
+        '--col-w1': String(widths[0] || 50),
+        '--col-w2': String(widths[1] || 50),
+        ...(columns === 3 ? { '--col-w3': String(widths[2] || 33) } : {}),
+      } as React.CSSProperties}
+      onMouseEnter={() => setShowToolbar(true)}
+      onMouseLeave={() => setShowToolbar(false)}
+    >
+      {/* Toolbar */}
+      {editor.isEditable && showToolbar && (
+        <div className="column-layout-toolbar" contentEditable={false}>
+          <button
+            className="column-toolbar-btn"
+            title={columns === 2 ? "Switch to 3 columns" : "Switch to 2 columns"}
+            onClick={toggleColumns}
+          >
+            {columns === 2 ? <Columns3 className="w-3.5 h-3.5" /> : <Columns2 className="w-3.5 h-3.5" />}
+          </button>
+          <button
+            className="column-toolbar-btn column-toolbar-btn-danger"
+            title="Remove column layout"
+            onClick={deleteNode}
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      )}
+
+      <div className="column-layout-inner" ref={containerRef}>
+        <NodeViewContent className="column-layout-content" />
+        {/* Resize handles – rendered between columns via CSS positioning */}
+        {editor.isEditable &&
+          Array.from({ length: columns - 1 }).map((_, i) => {
+            // Position handle at the cumulative width of columns 0..i
+            const leftPct = widths.slice(0, i + 1).reduce((a, b) => a + b, 0);
+            return (
+              <div
+                key={i}
+                className={`column-resize-handle${draggingIndex === i ? " active" : ""}`}
+                contentEditable={false}
+                style={{ left: `${leftPct}%` }}
+                onMouseDown={(e) => onMouseDown(e, i)}
+              />
+            );
+          })}
+      </div>
+    </NodeViewWrapper>
+  );
+};
+
+// ── ColumnLayout node (wrapper) ──────────────────────────────────────────────
+
+export const ColumnLayout = Node.create({
+  name: "columnLayout",
+  group: "block",
+  content: "columnBlock{2,3}",
+  defining: true,
+  isolating: true,
+
+  addAttributes() {
+    return {
+      columns: {
+        default: 2,
+        parseHTML: (element) => parseInt(element.getAttribute("data-columns") || "2", 10),
+        renderHTML: (attributes) => ({ "data-columns": attributes.columns }),
+      },
+      widths: {
+        default: "50,50",
+        parseHTML: (element) => element.getAttribute("data-widths") || "50,50",
+        renderHTML: (attributes) => ({ "data-widths": attributes.widths }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'div[data-type="columnLayout"]',
+        getAttrs: (dom) => {
+          const el = dom as HTMLElement;
+          return {
+            columns: parseInt(el.getAttribute("data-columns") || "2", 10),
+            widths: el.getAttribute("data-widths") || "50,50",
+          };
+        },
+      },
+    ];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, {
+        "data-type": "columnLayout",
+        "data-columns": node.attrs.columns,
+        "data-widths": node.attrs.widths,
+        class: "column-layout",
+      }),
+      0,
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ColumnLayoutNodeView);
+  },
+
+  addCommands() {
+    return {
+      insertColumnLayout:
+        (cols: number = 2) =>
+        ({ editor, commands }: any) => {
+          // Prevent nesting: don't insert if cursor is already inside a columnLayout
+          const { $from } = editor.state.selection;
+          for (let d = $from.depth; d > 0; d--) {
+            if ($from.node(d).type.name === "columnLayout") return false;
+          }
+
+          const columnBlocks = Array.from({ length: cols }).map(() => ({
+            type: "columnBlock",
+            content: [{ type: "paragraph" }],
+          }));
+
+          return commands.insertContent({
+            type: this.name,
+            attrs: { columns: cols, widths: defaultWidths(cols) },
+            content: columnBlocks,
+          });
+        },
+    } as any;
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      // When pressing Enter on an empty paragraph at the end of a column,
+      // break out of the column layout entirely
+      Enter: ({ editor }) => {
+        const { selection } = editor.state;
+        const { $from, empty } = selection;
+        if (!empty) return false;
+
+        // Check if we're inside a columnBlock
+        for (let depth = $from.depth; depth > 0; depth--) {
+          const node = $from.node(depth);
+          if (node.type.name === "columnBlock") {
+            const parent = $from.parent;
+            const isEmptyParagraph =
+              parent.type.name === "paragraph" && parent.content.size === 0;
+            const isLastChild = $from.index(depth) === node.childCount - 1;
+            if (isEmptyParagraph && isLastChild) {
+              // Find the columnLayout depth (one above columnBlock)
+              const layoutDepth = depth - 1;
+              if ($from.node(layoutDepth)?.type.name === "columnLayout") {
+                const pos = $from.after(layoutDepth);
+                return editor
+                  .chain()
+                  .deleteNode("paragraph")
+                  .insertContentAt(pos, { type: "paragraph" })
+                  .focus()
+                  .run();
+              }
+            }
+            break;
+          }
+        }
+        return false;
+      },
+      Backspace: ({ editor }) => {
+        const { selection } = editor.state;
+        const { $from, empty } = selection;
+        if (!empty) return false;
+        if ($from.parentOffset !== 0) return false;
+
+        // If at start of first block in a columnBlock, don't break the layout
+        for (let depth = $from.depth; depth > 0; depth--) {
+          const node = $from.node(depth);
+          if (node.type.name === "columnBlock") {
+            const indexInCol = $from.index(depth);
+            if (indexInCol === 0) {
+              // At start of first block in column – do nothing special
+              return true;
+            }
+            break;
+          }
+        }
+        return false;
+      },
+    };
+  },
+});

--- a/src/components/extensions/SlashCommands.tsx
+++ b/src/components/extensions/SlashCommands.tsx
@@ -9,6 +9,7 @@ import {
   Table, ImageIcon, ChevronDown, Lightbulb, Pencil, GitBranch,
   Minus, AlignLeft, AlignCenter, AlignRight, Link, Paperclip,
   FileText, CalendarDays, Clock, Sigma, FileImage, LayoutTemplate, Database, Palette,
+  Columns2, Columns3,
 } from "lucide-react";
 import { SlashCommandsList } from "./SlashCommandsList";
 import { PluginKey } from "@tiptap/pm/state";
@@ -278,6 +279,23 @@ const getSlashCommands = (): SlashCommandItem[] => [
         detail: { editor },
         bubbles: true,
       }));
+    },
+  },
+  // ── Layout ────────────────────────────────────────────────────────────────────
+  {
+    title: "2 Columns",
+    description: "Side-by-side two-column layout",
+    icon: <Columns2 className="h-4 w-4" />,
+    command: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).insertColumnLayout(2).run();
+    },
+  },
+  {
+    title: "3 Columns",
+    description: "Three-column layout",
+    icon: <Columns3 className="h-4 w-4" />,
+    command: ({ editor, range }) => {
+      editor.chain().focus().deleteRange(range).insertColumnLayout(3).run();
     },
   },
   // ── Date / Time ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds column layout to the TipTap editor. Slash commands /2 Columns and /3 Columns. Drag-to-resize, hover toolbar, nesting prevention, markdown round-trip. Closes #8. Co-Authored-By: Oz <oz-agent@warp.dev>