### PR TITLE
Potential fix for code scanning alert no. 10: Server-side request forgery

### DIFF
--- a/src/app/api/link-preview/route.ts
+++ b/src/app/api/link-preview/route.ts
@@ -1,4 +1,35 @@
 import { NextRequest, NextResponse } from "next/server";
+import dns from "dns/promises";
+import net from "net";
+
+function isPrivateOrLoopback(ip: string): boolean {
+  // IPv6 loopback
+  if (ip === "::1") return true;
+  // IPv4-mapped IPv6 addresses (e.g., ::ffff:127.0.0.1)
+  if (ip.startsWith("::ffff:")) {
+    ip = ip.substring("::ffff:".length);
+  }
+  if (net.isIPv4(ip)) {
+    const octets = ip.split(".").map(Number);
+    const [o1, o2] = octets;
+    // 10.0.0.0/8
+    if (o1 === 10) return true;
+    // 127.0.0.0/8
+    if (o1 === 127) return true;
+    // 172.16.0.0/12
+    if (o1 === 172 && o2 >= 16 && o2 <= 31) return true;
+    // 192.168.0.0/16
+    if (o1 === 192 && o2 === 168) return true;
+    // Link-local 169.254.0.0/16
+    if (o1 === 169 && o2 === 254) return true;
+  } else if (net.isIPv6(ip)) {
+    // Unique local addresses fc00::/7 and link-local fe80::/10
+    const lower = ip.toLowerCase();
+    if (lower.startsWith("fc") || lower.startsWith("fd")) return true;
+    if (lower.startsWith("fe80:")) return true;
+  }
+  return false;
+}
 
 export async function GET(req: NextRequest) {
   const url = req.nextUrl.searchParams.get("url");
@@ -9,6 +40,12 @@ export async function GET(req: NextRequest) {
   try {
     parsed = new URL(url);
     if (!["http:", "https:"].includes(parsed.protocol)) throw new Error("bad protocol");
+
+    // SSRF protection: resolve hostname and block private/loopback IPs
+    const addresses = await dns.lookup(parsed.hostname, { all: true });
+    if (addresses.length === 0 || addresses.some((a) => isPrivateOrLoopback(a.address))) {
+      return NextResponse.json({ error: "Forbidden host" }, { status: 400 });
+    }
   } catch {
     return NextResponse.json({ error: "Invalid URL" }, { status: 400 });
   }


### PR DESCRIPTION
Potential fix for [https://github.com/talder/Doc-it/security/code-scanning/10](https://github.com/talder/Doc-it/security/code-scanning/10)

In general, to fix this SSRF issue you must constrain which hosts the server is willing to contact on behalf of the user. Common strategies are: (1) allow‑list specific domains or domain suffixes; and/or (2) resolve the hostname server-side and reject targets whose IPs fall in private, loopback, link-local, or other sensitive ranges. Just checking `http/https` is not enough.

The least intrusive, functionality-preserving change here is to keep allowing arbitrary public `http/https` URLs, but explicitly block obvious internal destinations. That can be done by resolving `parsed.hostname` with `dns.promises.lookup`, examining the resulting IP address, and rejecting the request if it falls into private or loopback ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, ::1, link-local, etc.). We implement a small helper `isPrivateOrLoopback(ip: string): boolean` using Node’s built‑in `net` to classify addresses, and call it after parsing the URL but before `fetch`. If the host is disallowed, we return a 400/403 with an error JSON. This keeps the rest of the link-preview logic unchanged.

Concretely in `src/app/api/link-preview/route.ts`:
- Add imports for `dns/promises` and `net`.
- Add a helper function `isPrivateOrLoopback(ip: string): boolean`.
- After successfully creating `parsed = new URL(url)` and validating the protocol, resolve `parsed.hostname` via `dns.lookup` (with `all: true` to handle multi‑IP hosts) and reject if any resolved address is private/loopback. Only if the host passes this check do we proceed to the `fetch(parsed.toString(), ...)` call. The rest of the file remains the same.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
