### PR TITLE
Potential fix for code scanning alert no. 70: Uncontrolled data used in path expression

### DIFF
--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -14,6 +14,23 @@ import { broadcastNotification } from "./notification-bus";
 
 const NOTIF_DIR = path.join(process.cwd(), "config", "notifications");
 
+/**
+ * Sanitize a username so it is safe to use as a filename component.
+ * Only allow alphanumerics, underscore and hyphen; replace others with "_".
+ */
+function sanitizeUsernameForPath(username: string): string {
+  const trimmed = username.trim();
+  // Replace any character that is not A-Z, a-z, 0-9, underscore or hyphen
+  let safe = trimmed.replace(/[^a-zA-Z0-9_-]/g, "_");
+  // Collapse multiple underscores
+  safe = safe.replace(/_+/g, "_");
+  // Avoid empty filenames
+  if (!safe) {
+    safe = "unknown";
+  }
+  return safe;
+}
+
 // ---------------------------------------------------------------------------
 // Notification types
 // ---------------------------------------------------------------------------
@@ -38,7 +55,8 @@ export interface AppNotification {
 
 async function notifPath(username: string): Promise<string> {
   await ensureDir(NOTIF_DIR);
-  return path.join(NOTIF_DIR, `${username}.json`);
+  const safeUsername = sanitizeUsernameForPath(username);
+  return path.join(NOTIF_DIR, `${safeUsername}.json`);
 }
 
 export async function readNotifications(username: string): Promise<AppNotification[]> {


### PR DESCRIPTION
Potential fix for [https://github.com/talder/Doc-it/security/code-scanning/70](https://github.com/talder/Doc-it/security/code-scanning/70)

In general, to fix uncontrolled data in a path expression, either (a) strictly validate the user-controlled segment (here, `username`) to allow only safe filename characters and disallow path separators and traversal patterns, or (b) resolve the full path against a known safe root and verify that the resolved path remains within that root. Since we only need simple per-user JSON files named `{username}.json` and not nested directories, the simplest and safest approach is to treat `username` as a simple identifier and sanitize/validate it accordingly.

The best minimal fix here is to introduce a helper in `src/lib/notifications.ts` that turns an arbitrary `username` into a safe filename component (for example, by whitelisting allowed characters and replacing others, or by rejecting invalid names), and then use that sanitized value when building the path in `notifPath`. This change is localized to `notifications.ts` and does not alter the observable behavior for normal, valid usernames, but it blocks directory traversal and weird filenames. A straightforward approach is:

- Add a function `sanitizeUsernameForPath(username: string): string` in `notifications.ts` that:
  - Trims the input.
  - Replaces any character not in a safe set (e.g., `[A-Za-z0-9_-]`) with an underscore.
  - Collapses runs of underscores and optionally falls back to `"unknown"` if the result is empty.
- Update `notifPath` to call this sanitizer and use the sanitized string when forming `${username}.json`.

We do not need extra libraries for this; TypeScript/JavaScript’s built-in `String.replace` with a regular expression is sufficient. No changes are needed in `route.ts`; the dangerous part is the unvalidated use of `username` in the filesystem path, which we fix centrally in `notifPath`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
