### PR TITLE
feat: add PFX export format for certificates

### DIFF
--- a/src/components/admin/CertificatesTab.tsx
+++ b/src/components/admin/CertificatesTab.tsx
@@ -275,7 +275,7 @@ export default function CertificatesTab() {
   const [pendingExport, setPendingExport] = useState<{ type: "cert" | "key"; id: string; format: string } | null>(null);
 
   const triggerExport = (type: "cert" | "key", id: string, format: string) => {
-    if (format === "PEM+key" || format === "PKCS12") {
+    if (format === "PEM+key" || format === "PKCS12" || format === "PFX") {
       setCertExportPassphrase("");
       setCertExportPassVisible(false);
       setPendingExport({ type, id, format });
@@ -765,6 +765,7 @@ export default function CertificatesTab() {
                         <option value="PKCS7-chain">PKCS #7 all (*.p7b)</option>
                         <option value="PEM-chain">PEM all (*.pem)</option>
                         <option value="PKCS12">PKCS #12 (*.p12)</option>
+                        <option value="PFX">PFX (*.pfx)</option>
                         <option value="PEM+key">PEM + Key (*.pem)</option>
                         <option value="cert-index">Certificate Index (*.txt)</option>
                       </select>

--- a/src/lib/certificates.ts
+++ b/src/lib/certificates.ts
@@ -1345,7 +1345,7 @@ export async function exportCert(
     return { data: b64, mimeType: "application/pkcs7-mime", filename: `${safeName}.p7b` };
   }
 
-  if (format === "PKCS12") {
+  if (format === "PKCS12" || format === "PFX") {
     const forgeCert = forge.pki.certificateFromPem(cert.pem);
     let forgeKey: forge.pki.rsa.PrivateKey | null = null;
     if (cert.keyId) {
@@ -1368,7 +1368,8 @@ export async function exportCert(
     const p12Asn1 = forge.pkcs12.toPkcs12Asn1(forgeKey, certChain, passphrase || "", { algorithm: "3des" });
     const p12Der = forge.asn1.toDer(p12Asn1).getBytes();
     const b64 = Buffer.from(p12Der, "binary").toString("base64");
-    return { data: b64, mimeType: "application/x-pkcs12", filename: `${safeName}.p12` };
+    const ext = format === "PFX" ? "pfx" : "p12";
+    return { data: b64, mimeType: "application/x-pkcs12", filename: `${safeName}.${ext}` };
   }
 
   if (format === "PEM+key") {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -615,6 +615,7 @@ export type PkiExportFormat =
   | "PKCS7"
   | "PKCS7-chain"
   | "PKCS12"
+  | "PFX"
   | "PEM-chain"
   | "PEM+key"
   | "cert-index";


### PR DESCRIPTION
Add PFX (*.pfx) as a certificate export option alongside the existing PKCS#12 (*.p12) format. Both produce identical PKCS#12 content but PFX uses the .pfx file extension expected by some tools.